### PR TITLE
Added validators to ChatSerializer and ChatParticipantSerializer

### DIFF
--- a/voicengerapp/serializers/chat.py
+++ b/voicengerapp/serializers/chat.py
@@ -3,12 +3,21 @@ from ..models import Chat, ChatParticipant
 
 # Сериализатор для чатов
 class ChatSerializer(serializers.ModelSerializer):
+    def validat_closed_at(self, value):
+        if value and value < self.instance.created_at:
+            raise serializers.ValidationError("The closing date cannot be earlier than the chat creation date.")
+        return value
     class Meta:
         model = Chat
         fields = '__all__'
 
 # Сериализатор для участников чатов
 class ChatParticipantSerializer(serializers.ModelSerializer):
+
+    def validate(self, data):
+        if ChatParticipant.objects.filter(user=data['user'], chat=data['chat']).exists():
+            raise serializers.ValidationError("The user is already a member of this chat room.")
+        return data
     class Meta:
         model = ChatParticipant
         fields = '__all__'


### PR DESCRIPTION
- Added a validator in ChatSerializer to check the chat's closing date (`closed_at`):
- The closing date cannot be earlier than the chat's creation date.
- Added a validator in ChatParticipantSerializer:
- Ensures that a user cannot be added to the same chat twice.